### PR TITLE
Step 10 - Retrieve tamperable memcpy calls

### DIFF
--- a/10_taint_tracking.ql
+++ b/10_taint_tracking.ql
@@ -1,1 +1,32 @@
+/**
+* @kind path-problem
+*/
 
+import cpp
+import semmle.code.cpp.dataflow.TaintTracking
+import DataFlow::PathGraph
+ 
+class NetworkByteSwap extends Expr {
+    NetworkByteSwap(){
+        exists(MacroInvocation nvk | nvk.getMacroName().regexpMatch("ntoh.*") and this = nvk.getExpr())
+    }
+}
+ 
+class Config extends TaintTracking::Configuration {
+  Config() { this = "NetworkToMemFuncLength" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source.asExpr() instanceof NetworkByteSwap
+  }
+  override predicate isSink(DataFlow::Node sink) {
+    exists(FunctionCall call |
+        call.getTarget().getName() = "memcpy" and
+        sink.asExpr() = call.getArgument(2) and
+        not call.getArgument(2).isConstant()
+    )
+    }
+}
+
+from Config cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink, source, sink, "Network byte swap flows to memcpy"


### PR DESCRIPTION
Retrieve calls for "memcpy" where network data (which user has access to) is flown into the 3rd (length) parameter, allowing for overflowing to occur.